### PR TITLE
docs: align dashboard page with Issue #3 — Vite + `react-ts` decision

### DIFF
--- a/docs/pg-atlas/dashboard.md
+++ b/docs/pg-atlas/dashboard.md
@@ -61,9 +61,9 @@ The dashboard should be public, zero-auth (read-only), mobile-responsive, and fo
 
 ## Technology Decision
 
-**Decided (Issue #3):** **Vite with TypeScript** (React). The dashboard will be a custom TypeScript
-frontend, consuming the RESTful FastAPI backend exclusively (no direct DB access) and dogfooding our
-OpenAPI-generated TypeScript SDK.
+**Decided (Issue #3):** **Vite with TypeScript** (`react-ts` template). The dashboard will be a
+custom TypeScript frontend, consuming the RESTful FastAPI backend exclusively (no direct DB access)
+and dogfooding our OpenAPI-generated TypeScript SDK.
 
 ### Rationale
 
@@ -82,7 +82,7 @@ OpenAPI-generated TypeScript SDK.
 
 ### Ownership
 
-[KoxyG](https://github.com/KoxyG) has taken ownership: build with **Vite with TypeScript**.
+[KoxyG](https://github.com/KoxyG) has taken ownership: build with **Vite's `react-ts` template**.
 [GitHub Issue #3](https://github.com/scf-public-goods-maintenance/scf-public-goods-maintenance.github.io/issues/3).
 
 ## Open Questions

--- a/docs/pg-atlas/operations.md
+++ b/docs/pg-atlas/operations.md
@@ -37,7 +37,7 @@ Security: HTTPS enforced, rate limiting, no public writes.
 - Hosted PostgreSQL.
 - FastAPI container on DigitalOcean App Platform (managed PaaS, auto-deploys from GitHub).
 - Periodic workers: App Platform background workers or separate Celery container.
-- Dashboard: Static build (Next.js) on App Platform static site or separate.
+- Dashboard: Static build on App Platform static site or separate.
 
 **Pros**:
 


### PR DESCRIPTION
Updates the PG Atlas Dashboard doc to match the decision from Issue #3.

**Changes:**
- Replaced the previous "Implementation Options" section (Streamlit, Dash, React/Next.js) with a "Technology Decision" section that records the chosen approach.
- **Decision:** Option C — React/Next.js (or Vite) for the dashboard. No Panel prototype in the chosen path.
- **Rationale:** TypeScript SDK dogfooding, contributor accessibility (React/TS ecosystem), and a scoped v0 (leaderboard + basic PG detail pages; graph explorer deferred to v1).
- **Ownership:** KoxyG — Next.js or Vite, coordinating with the team to finalize features.
- Trimmed "Open Questions" to items still open (graph lib, hosting, analytics, mockups).

Resolves the doc drift noted in https://github.com/scf-public-goods-maintenance/scf-public-goods-maintenance.github.io/issues/3 (dashboard page now consistent with the Build submission and issue resolution).