### PR TITLE
Add PG Award intake form

### DIFF
--- a/.github/workflows/ISSUE_TEMPLATE/pg-award-intake-form.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/pg-award-intake-form.yml
@@ -1,0 +1,178 @@
+name: SCF Public Goods Award - Intake Form
+description: Submit your project for consideration for the SCF Public Goods Award
+title: "PG Award Intake: "
+labels: ["pg-award-intake"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # SCF Public Goods Award: Intake Form
+
+        Thank you for your interest in the SCF Public Goods Award.
+
+        **Important note on eligibility**:
+        If this project was voted on in a previous Public Goods Award round, you are eligible to create a proposal directly on [Tansu](https://testnet.tansu.dev/project/?name=stellarpg). You do **not** need to fill out this form.
+
+  - type: input
+    id: project-name
+    attributes:
+      label: Project Name
+      description: Max 128 characters
+      placeholder: e.g. StellarExpert Explorer
+    validations:
+      required: true
+
+  - type: textarea
+    id: one-sentence
+    attributes:
+      label: Describe your project in one sentence
+      description: Max 32 words
+      placeholder:
+        e.g A Soroban-focused block explorer optimized for smart contract visibility and developer
+        tooling.
+    validations:
+      required: true
+
+  - type: input
+    id: release-date
+    attributes:
+      label: When was your project first released?
+      description: Month and year is sufficient
+      placeholder: e.g. March 2024
+    validations:
+      required: true
+
+  - type: dropdown
+    id: pg-history
+    attributes:
+      label: Your history with the PG Award
+      description: Is this your first time submitting to the SCF Public Goods Award?
+      options:
+        - Yes, it's my first time submitting a proposal for the Public Goods Award
+        - Yes, it's my first time submitting to this Award, but I've received SDF Infrastructure
+          Grants before.
+        - No, I've submitted before to the Public Goods Award (eligible to create a proposal directly
+          on Tansu — you do not need to fill out this form)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Project Category
+      description:
+        Take a look at the [Public Good
+        Categories](https://scf-public-goods-maintenance.github.io/public-goods-award/#public-good-categories)
+        to learn more.
+      options:
+        - SDKs
+        - Data Support
+        - Wallet Support
+        - Developer Experience
+        - Ecosystem Visibility
+        - Infrastructure Monitoring
+        - Governance Tools
+        - Security & Auditing Tools
+        - Compliance & Identity Tooling
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: project-description
+    attributes:
+      label: Project Description
+      description: Detailed description of what your project does and its impact.
+      placeholder: Max 128 words
+    validations:
+      required: true
+
+  - type: input
+    id: website
+    attributes:
+      label: Website
+      description: Product website or documentation site (different than Git URL).
+      placeholder: https://yourproject.com
+    validations:
+      required: true
+
+  - type: input
+    id: git-repo
+    attributes:
+      label: Public Git Repository
+      description: E.g. GitHub org or repo URL, whichever best fits the scope of your project.
+      placeholder: https://github.com/owner/repo
+    validations:
+      required: true
+
+  - type: input
+    id: license
+    attributes:
+      label: Open-Source License
+      description:
+        Which open-source license is applied to the majority of your source code? (max 64 characters)
+      placeholder: e.g. MIT, Apache-2.0, GPL-3.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: revenue-model
+    attributes:
+      label: Does your project have a revenue model?
+      options:
+        - "No"
+        - "Yes"
+    validations:
+      required: true
+
+  - type: textarea
+    id: revenue-details
+    attributes:
+      label: Current sources of revenue (if applicable)
+      description:
+        "Report all direct sources of income for your public good, including: donations, usage fees,
+        awards, grants, and corporate sponsorships. Max 64 words."
+      placeholder: Only complete if you answered "Yes" above.
+    validations:
+      required: false
+
+  - type: textarea
+    id: traction
+    attributes:
+      label: How much traction does your project have within the Stellar ecosystem?
+      description: What makes it critical to the Stellar ecosystem? Max 64 words.
+      placeholder:
+        e.g. end user-facing products built upon your project (directly or indirectly), Total Value
+        Locked, and/or Monthly Active Users.
+    validations:
+      required: true
+
+  - type: textarea
+    id: pg-qualification
+    attributes:
+      label: Why does your project qualify as a Stellar public good?
+      description:
+        Is there any way in which it is [excludable](https://en.wikipedia.org/wiki/Excludability)?
+        Also see [eligibility
+        criteria](https://scf-public-goods-maintenance.github.io/public-goods-award/#eligibility-criteria).
+    validations:
+      required: true
+
+  - type: textarea
+    id: team-experience
+    attributes:
+      label: Describe your team members and your team's experience with the Stellar ecosystem
+      description:
+        For FOSS projects, your "team" includes maintainers and recurring contributors (not drive-by
+        contributors). Include for each member their GitHub profile, Discord handle, and LinkedIn
+        profile if available.
+      placeholder:
+        List each member, and mention previous SCF participation, ecosystem contributions, projects
+        built on Stellar.
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        Thank you! Once submitted, the SCF Pilots will review your intake form. If eligible, you will be invited to create a formal proposal on Tansu.


### PR DESCRIPTION
The intake process will take place here on GitHub from Q2 onward. Implemented using the issue form feature.

Projects that are interested in participating must submit this form to receive an eligibility check done by SCF Pilots. I'm adding some validation scripts to ensure that issues created with the form are at least surface-level comparable, and to protect reviewers from too long content we haven't asked for.