### PR TITLE
Add proposal automation pipeline and documentation

### DIFF
--- a/.github/scripts/render_proposal.py
+++ b/.github/scripts/render_proposal.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Render a parsed PG Award proposal issue form into a Jekyll project page.
+
+Reads env vars set by issue-ops/parser in a GitHub Actions workflow:
+  PARSED_JSON  — JSON string from the parser step
+  ISSUE_NUMBER — GitHub issue number
+  ISSUE_AUTHOR — GitHub username of the issue author
+
+Writes:
+  docs/projects/{slug}.md
+
+Outputs (to $GITHUB_OUTPUT):
+  slug, file_path, project_title
+"""
+
+import json
+import os
+import re
+import sys
+import textwrap
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def slugify(name: str, max_len: int = 64) -> str:
+    """Lowercase, replace non-alnum with hyphens, collapse, strip, truncate."""
+    s = name.lower()
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    s = s.strip("-")
+    return s[:max_len].rstrip("-")
+
+
+def unwrap_dropdown(value):
+    """Parser returns dropdown values as '["Value"]'; extract the string."""
+    if isinstance(value, list):
+        return value[0] if value else ""
+    return str(value)
+
+
+def format_checkboxes(value) -> str:
+    """Format checkboxes dict into readable markdown."""
+    if isinstance(value, dict):
+        lines = []
+        for item in value.get("selected", []):
+            lines.append(f"- [x] {item}")
+        for item in value.get("unselected", []):
+            lines.append(f"- [ ] {item}")
+        return "\n".join(lines)
+    return str(value)
+
+
+def write_github_output(pairs: dict[str, str]):
+    """Append key=value pairs to $GITHUB_OUTPUT."""
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if output_file:
+        with open(output_file, "a") as f:
+            for k, v in pairs.items():
+                f.write(f"{k}={v}\n")
+    else:
+        # Local testing: print to stderr
+        for k, v in pairs.items():
+            print(f"  {k}={v}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    raw = os.environ.get("PARSED_JSON")
+    if not raw:
+        sys.exit("Error: PARSED_JSON environment variable is not set")
+
+    issue_number = os.environ.get("ISSUE_NUMBER", "0")
+    issue_author = os.environ.get("ISSUE_AUTHOR", "unknown")
+
+    parsed = json.loads(raw)
+
+    # --- Extract fields -------------------------------------------------------
+    project_name = str(parsed.get("project-name", "Untitled Project"))
+    one_sentence = str(parsed.get("one-sentence", ""))
+    intake_link = str(parsed.get("pg-award-intake", ""))
+    release_date = str(parsed.get("release-date", ""))
+    category = unwrap_dropdown(parsed.get("category", "Other"))
+    description = str(parsed.get("project-description", ""))
+    website = str(parsed.get("website", ""))
+    git_repo = str(parsed.get("git-repo", ""))
+    team_experience = str(parsed.get("team-experience", ""))
+    retro_impact = str(parsed.get("pg-retroactive-impact", ""))
+    retro_deliverable = str(parsed.get("pg-retroactive-deliverable", ""))
+    proposal_impact = str(parsed.get("pg-proposal-impact", ""))
+    proposal_deliverable = str(parsed.get("pg-proposal-deliverable", ""))
+    budget_ask = str(parsed.get("budget-ask", ""))
+    legal = format_checkboxes(parsed.get("legal-acknowledgements", ""))
+
+    slug = slugify(project_name)
+    if not slug:
+        slug = f"project-{issue_number}"
+
+    # --- Build page -----------------------------------------------------------
+    front_matter = textwrap.dedent(
+        f"""\
+        ---
+        title: "{project_name.replace('"', '\\"')}"
+        parent: Public Good Projects
+        proposal_issue: {issue_number}
+        proposer: {issue_author}
+        category: "{category.replace('"', '\\"')}"
+        budget: "{budget_ask.replace('"', '\\"')}"
+        ---
+    """
+    )
+
+    body_parts = [
+        f"# {project_name}\n",
+        f"_{one_sentence}_\n",
+        "| | |",
+        "| --- | --- |",
+        f"| **Category** | {category} |",
+        f"| **Website** | {website} |",
+        f"| **Repository** | {git_repo} |",
+        f"| **First Released** | {release_date} |",
+        f"| **Intake** | {intake_link} |",
+        f"| **Budget Requested** | {budget_ask} |",
+        "",
+        "## Project Description\n",
+        description,
+        "",
+        "## Team & Experience\n",
+        team_experience,
+        "",
+        "## Retroactive Impact\n",
+        retro_impact,
+        "",
+        "## Past Deliverables\n",
+        retro_deliverable,
+        "",
+        "## Proposed Impact\n",
+        proposal_impact,
+        "",
+        "## Proposed Deliverables\n",
+        proposal_deliverable,
+        "",
+        "## Legal Acknowledgements\n",
+        legal,
+        "",
+    ]
+
+    content = front_matter + "\n".join(body_parts) + "\n"
+
+    # --- Write file -----------------------------------------------------------
+    out_dir = os.path.join("docs", "projects")
+    os.makedirs(out_dir, exist_ok=True)
+    file_path = os.path.join(out_dir, f"{slug}.md")
+
+    with open(file_path, "w") as f:
+        f.write(content)
+
+    print(f"Rendered {file_path} ({len(content)} bytes)")
+
+    # --- Outputs --------------------------------------------------------------
+    write_github_output(
+        {
+            "slug": slug,
+            "file_path": file_path,
+            "project_title": project_name,
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/pg-award-proposal-genesis.yml
+++ b/.github/workflows/pg-award-proposal-genesis.yml
@@ -1,0 +1,175 @@
+name: PG Award Proposal - Genesis
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  genesis:
+    if: contains(github.event.issue.labels.*.name, 'pg-award-proposal')
+    runs-on: ubuntu-latest
+
+    steps:
+      # ── Re-entry guard ────────────────────────────────────────────────────
+      # If the issue already spawned a PR, skip everything and leave a comment.
+      - name: Check for existing PR
+        id: reentry
+        if: contains(github.event.issue.labels.*.name, 'pg-proposal:pr-created')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} \
+            -R ${{ github.repository }} \
+            --body "⚠️ A proposal PR was already created from this issue. Please edit the project page on the PR branch instead."
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+
+      - name: Abort if PR already exists
+        if: steps.reentry.outputs.skip == 'true'
+        run: |
+          echo "::notice::Skipping — PR already created for this issue."
+          exit 0
+
+      # ── Parse & validate ──────────────────────────────────────────────────
+      - name: Checkout repo
+        if: steps.reentry.outputs.skip != 'true'
+        uses: actions/checkout@v4
+
+      - name: Parse proposal form
+        if: steps.reentry.outputs.skip != 'true'
+        id: parse
+        uses: issue-ops/parser@v5
+        with:
+          body: ${{ github.event.issue.body }}
+          issue-form-template: pg-award-proposal-form.yml
+
+      - name: Validate proposal form
+        if: steps.reentry.outputs.skip != 'true'
+        id: validate
+        uses: issue-ops/validator@v4
+        with:
+          issue-form-template: pg-award-proposal-form.yml
+          parsed-issue-body: ${{ steps.parse.outputs.json }}
+          add-comment: true
+
+      - name: Label on validation failure
+        if: steps.reentry.outputs.skip != 'true' && steps.validate.outputs.result != 'success'
+        uses: issue-ops/labeler@v4
+        with:
+          action: add
+          create: true
+          issue_number: ${{ github.event.issue.number }}
+          labels: |
+            issueops:validation-error
+
+      - name: Abort on validation failure
+        if: steps.reentry.outputs.skip != 'true' && steps.validate.outputs.result != 'success'
+        run: |
+          echo "::error::Proposal form validation failed. A comment has been posted on the issue."
+          exit 1
+
+      # ── Clear validation-error label on success ───────────────────────────
+      - name: Remove validation-error label
+        if: steps.reentry.outputs.skip != 'true'
+        uses: issue-ops/labeler@v4
+        with:
+          action: remove
+          issue_number: ${{ github.event.issue.number }}
+          labels: |
+            issueops:validation-error
+
+      # ── Render project page ───────────────────────────────────────────────
+      - name: Render project page from parsed form
+        if: steps.reentry.outputs.skip != 'true'
+        id: render
+        env:
+          PARSED_JSON: ${{ steps.parse.outputs.json }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+        run: python .github/scripts/render_proposal.py
+
+      # ── Create branch, commit, push ───────────────────────────────────────
+      - name: Determine branch name
+        if: steps.reentry.outputs.skip != 'true'
+        id: branch
+        run: |
+          SLUG="${{ steps.render.outputs.slug }}"
+          BRANCH="proposals/${SLUG}"
+          if git ls-remote --heads origin "$BRANCH" | grep -q .; then
+            BRANCH="proposals/${SLUG}-${{ github.event.issue.number }}"
+          fi
+          echo "name=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push project page
+        if: steps.reentry.outputs.skip != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${{ steps.branch.outputs.name }}"
+          git add "${{ steps.render.outputs.file_path }}"
+          git commit -m "Add project page: ${{ steps.render.outputs.project_title }}"
+          git push origin "${{ steps.branch.outputs.name }}"
+
+      # ── Create PR ─────────────────────────────────────────────────────────
+      - name: Create Pull Request
+        if: steps.reentry.outputs.skip != 'true'
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "${{ steps.branch.outputs.name }}" \
+            --title "PG Award Proposal: ${{ steps.render.outputs.project_title }}" \
+            --body-file "${{ steps.render.outputs.file_path }}" \
+            --label "pg-award-proposal")
+          echo "url=${PR_URL}" >> "$GITHUB_OUTPUT"
+
+      # ── Close issue with link to PR ───────────────────────────────────────
+      - name: Close issue and link to PR
+        if: steps.reentry.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue close ${{ github.event.issue.number }} \
+            -R ${{ github.repository }} \
+            --comment "⚡ Your proposal PR has been created: ${{ steps.pr.outputs.url }}
+
+          **Next steps:**
+          1. Edit your project page directly on the PR branch during the Discussion & Revisions phase.
+          2. Use the GitHub web editor (pencil icon) or clone locally.
+          3. Every commit to the project page auto-updates the PR description.
+
+          See [Proposer Instructions](https://scf-public-goods-maintenance.github.io/pg-award/proposer-instructions/) for the full process."
+
+      # ── Label issue as PR-created ─────────────────────────────────────────
+      - name: Add pr-created label
+        if: steps.reentry.outputs.skip != 'true'
+        uses: issue-ops/labeler@v4
+        with:
+          action: add
+          create: true
+          issue_number: ${{ github.event.issue.number }}
+          labels: |
+            pg-proposal:pr-created
+
+      # ── Step summary ──────────────────────────────────────────────────────
+      - name: Write step summary
+        if: steps.reentry.outputs.skip != 'true'
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Proposal Genesis
+
+          | | |
+          | --- | --- |
+          | **Issue** | #${{ github.event.issue.number }} |
+          | **Project** | ${{ steps.render.outputs.project_title }} |
+          | **Slug** | \`${{ steps.render.outputs.slug }}\` |
+          | **File** | \`${{ steps.render.outputs.file_path }}\` |
+          | **Branch** | \`${{ steps.branch.outputs.name }}\` |
+          | **PR** | ${{ steps.pr.outputs.url }} |
+          EOF

--- a/.github/workflows/pg-award-proposal-sync.yml
+++ b/.github/workflows/pg-award-proposal-sync.yml
@@ -1,0 +1,89 @@
+name: PG Award Proposal - Sync PR Body
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - "docs/projects/**.md"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Find changed project files
+        id: files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CHANGED=$(gh pr diff ${{ github.event.pull_request.number }} \
+            -R ${{ github.repository }} \
+            --name-only \
+            | grep '^docs/projects/.*\.md$' \
+            | grep -v '/index\.md$' \
+            || true)
+
+          COUNT=$(echo "$CHANGED" | grep -c . || true)
+          echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
+
+          if [[ "$COUNT" -eq 1 ]]; then
+            echo "path=${CHANGED}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip if no project files changed
+        if: steps.files.outputs.count == '0'
+        run: echo "::notice::No project page changes detected — skipping sync."
+
+      - name: Fail if multiple project files changed
+        if: steps.files.outputs.count > 1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            -R ${{ github.repository }} \
+            --body "⚠️ This PR modifies multiple project pages. Please only modify one project page per PR so the proposal can be synced correctly."
+          exit 1
+
+      - name: Strip front matter and sync PR body
+        if: steps.files.outputs.count == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          FILE="${{ steps.files.outputs.path }}"
+          MAX_CHARS=64000
+
+          # Strip YAML front matter (first --- to second --- inclusive)
+          BODY=$(sed '1{/^---$/!q}; 1,/^---$/d' "$FILE")
+
+          BODY_LEN=${#BODY}
+          TRUNCATED="false"
+
+          if [[ "$BODY_LEN" -gt "$MAX_CHARS" ]]; then
+            BODY="${BODY:0:$MAX_CHARS}"
+            BODY+=$'\n\n---\n⚠️ This proposal has been truncated due to length. View the full proposal in the [Files changed](../pull/'"$PR_NUMBER"'/files) tab.'
+            TRUNCATED="true"
+          fi
+
+          echo "$BODY" | gh pr edit "$PR_NUMBER" \
+            -R ${{ github.repository }} \
+            --body-file -
+
+          # Step summary
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Proposal Sync
+
+          | | |
+          | --- | --- |
+          | **PR** | #${PR_NUMBER} |
+          | **File** | \`${FILE}\` |
+          | **Content length** | ${BODY_LEN} chars |
+          | **Truncated** | ${TRUNCATED} |
+          EOF

--- a/docs/_includes/footer_custom.html
+++ b/docs/_includes/footer_custom.html
@@ -68,3 +68,11 @@
     color: var(--global-text-color);
   }
 </style>
+
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: true });
+  document.querySelectorAll('pre > code.language-mermaid').forEach((codeBlock) => {
+    codeBlock.parentElement.outerHTML = `<pre class="mermaid">${codeBlock.textContent}</pre>`;
+  });
+</script>

--- a/docs/pg-award/proposer-instructions.md
+++ b/docs/pg-award/proposer-instructions.md
@@ -1,0 +1,172 @@
+---
+title: Proposer Instructions
+parent: Public Goods Award
+nav_order: 3
+---
+
+# Proposer Instructions
+
+The SCF Public Goods Award provides quarterly funding for maintenance, security, and incremental
+evolution of open-source public goods in the Stellar ecosystem. This page walks proposers through the
+full lifecycle — from intake eligibility through proposal submission, community review, on-chain
+voting, award distribution, and renewal.
+
+## Intake Process (Rolling Admissions)
+
+The intake process determines whether a project is eligible to submit a formal proposal. Intake is
+**always open** — there is no deadline. Projects can submit an intake form at any time, and approved
+projects can submit a proposal in the next available quarterly round.
+
+### How It Works
+
+1. **Submit the Intake Form.** Open a
+   [new Intake Form issue](https://github.com/SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io/issues/new?template=pg-award-intake-form.yml){:target="⚡"}
+   in this repository.
+2. **Automated validation.** The form is validated automatically. If there are errors, the bot will
+   flag them and you can edit your issue to fix them.
+3. **Eligibility discussion.** Once validated, your intake enters the `pg-intake:in-review` state.
+   SCF members — especially Pilots — discuss your project in the issue thread. This period lasts a
+   minimum of 7 days. Pilots signal their position by reacting with 👍 or 👎.
+4. **Quorum check.** A Pilot runs the `.quorum-check` command. The bot counts pilot reactions:
+   - Minimum 3 voters required.
+   - Acceptance formula: `ups ≥ 3 + 2 × downs` (each downvote raises the bar by 2 upvotes).
+5. **Decision.** The issue is labeled `pg-intake:accepted` or `pg-intake:rejected`, then closed and
+   locked. If rejected, only Pilots can reopen the intake and discussion.
+
+Once accepted, you are eligible to submit a proposal in the next quarterly round.
+
+```mermaid
+flowchart TD
+    A["Proposer submits\nIntake Form\n(GitHub Issue)"] --> B["Automated validation\n(issue-ops parser + validator)"]
+    B -->|"valid"| C["Label: pg-intake:in-review\nBot posts: Ready for Eligibility Review"]
+    B -->|"invalid"| D["Label:\nissueops:validation-error\nBot posts error comment"]
+    D --> E["Proposer edits issue\n(triggers re-validation)"]
+    E --> B
+    C --> F["SCF members discuss\n(≥7 days)\nPilots react 👍 / 👎"]
+    F --> G["A Pilot runs\n.quorum-check command"]
+    G --> H{"Quorum met?\n(≥3 voters)"}
+    H -->|"No"| I["Bot: not enough votes yet"]
+    I --> F
+    H -->|"Yes"| J{"Accepted?\n(ups ≥ 3 + 2 × downs)"}
+    J -->|"Yes"| K["Label: pg-intake:accepted\nIssue closed & locked"]
+    J -->|"No"| L["Label: pg-intake:rejected\nIssue closed & locked"]
+    K --> M["Proposer is now eligible\nto submit a Proposal"]
+    L --> N["Only Pilots can reopen the\nintake and discussion"]
+```
+
+## Proposal Process — Quarterly Timeline
+
+**Eligibility:** Only projects approved through intake or through previous Award participation may
+submit the proposal form. Ineligible use of the form is publicly visible.
+
+| Phase                             | Description                                                                                                                                                                                                                                                                                                                                                                             | Duration               |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| 1️⃣ Proposal Submission            | Proposer fills out the [Proposal Form](https://github.com/SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io/issues/new?template=pg-award-proposal-form.yml){:target="⚡"} (GitHub Issue). Automation validates the submission, generates a project page, and creates a Pull Request. The issue is closed with a link to the PR. For renewals, see [below](#renewals). | Quarterly window       |
+| 2️⃣ Discussion & Revisions (D&R)   | Community reviews the proposal PR on GitHub. Proposer edits the project page directly on the PR branch; the PR description auto-syncs on every commit. Previous deliverables are also reviewed during this phase. Early entrants have more time for revisions; late entrants have less.                                                                                                 | ~7 days                |
+| 3️⃣ On-chain Submission            | At the close of the D&R window, revised proposals are submitted to [Tansu](https://tansu.dev){:target="⚡"} for on-chain voting.                                                                                                                                                                                                                                                        | Within 2 business days |
+| 4️⃣ On-chain Vote                  | SCF Pilots vote on proposals using NQG-weighted scores on Tansu.                                                                                                                                                                                                                                                                                                                        | ~3 days                |
+| 5️⃣ SDF Compliance & Payout Setup  | After community approval, SDF performs a final compliance check. At SDF's discretion, if a community-approved proposal does not meet Award eligibility, the project is not awarded.                                                                                                                                                                                                     | ~1 week                |
+| 6️⃣ Award Distribution — Tranche 1 | First 50% of the award is distributed after approval and payment setup.                                                                                                                                                                                                                                                                                                                 | ~1 week                |
+| 7️⃣ Award Distribution — Tranche 2 | Second 50% is distributed after reviewers approve previous deliverables (supermajority required).                                                                                                                                                                                                                                                                                       | Next quarter           |
+
+```mermaid
+flowchart TD
+    subgraph new ["New Proposal"]
+        A1["Proposer fills out\nProposal Form\n(GitHub Issue)"] --> B1["🤖 Genesis Action:\n1. validate\n2. render project page\n3. create branch + PR\n4. close issue"]
+    end
+    subgraph renewal ["Update and optional Renewal Proposal"]
+        A2["Proposer edits\nexisting project page"] --> B2["Opens PR from new branch:\nproposals/{slug}-{quarter}"]
+    end
+    B1 --> C["Proposal PR open\non GitHub"]
+    B2 --> C
+    C -->|"D&R phase starts"| D["Discussion & Revisions\n(~7 days)\nCommunity reviews on PR"]
+    D --> E["🤖 Sync Action:\nPR body updates on each commit"]
+    E --> D
+    D -->|"D&R phase ends"| F["Proposal finalized\n(D&R window closed)"]
+    F --> G["Proposal submitted to\nTansu for on-chain vote"]
+    G --> H["SCF Pilots vote\n(NQG-weighted, ~3 days)"]
+    H --> J{"Approved?"}
+    J -->|"Yes"| K["Handoff to SDF for\ncompliance check"]
+    J -->|"No"| L["Proposal not awarded\n(PR is not merged)"]
+    K --> M{"SDF compliance\npassed?"}
+    M -->|"Yes"| N["Tranche 1: 50% distributed\n(~1 week)"]
+    M -->|"No"| O["Project not awarded\n(at SDF discretion)"]
+    N -->|"Next quarter"| A2
+    D --> S{"Has previous\ndeliverables?"}
+    subgraph review ["Deliverables Review"]
+        S -->|"Yes"| T["Reviewers approve\n or comment"]
+        T --> U{"Supermajority\napproves?"}
+        U --> V["Tranche 2: 50% \ndistributed(~1 week)"]
+    end
+```
+
+## Filling Out the Proposal Form
+
+The
+[Proposal Form](https://github.com/SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io/issues/new?template=pg-award-proposal-form.yml){:target="⚡"}
+is mostly self-explanatory. A few things to keep in mind:
+
+- **Project Name** is used to generate the URL slug for your project page (e.g., "StellarExpert
+  Explorer" → `stellarexpert-explorer`). Choose a clear, recognizable name.
+- **PG Intake Form** — link to your approved intake issue. If you submitted through Airtable during
+  the soft-launch period, write "soft-launch".
+- **Budget Requested** — up to $50,000 in XLM per quarter. Your budget should be reasonable relative
+  to your retroactive impact and planned deliverables.
+- **Legal Acknowledgements** — you must agree to the
+  [Legal Acknowledgements](https://stellar.gitbook.io/scf-handbook/supporting-programs/public-goods-award/legal-acknowledgements){:target="⚡"}
+  provided by SDF. This is required to proceed.
+
+**Tip:** Links in the form open in your current browser tab by default. Draft your answers in a
+separate file first, or copy them as a backup before submitting.
+
+## Discussion & Revisions (D&R)
+
+After you submit the Proposal Form, automation creates a Pull Request containing your project page
+and closes the issue with a link to the PR. From that point on, **the PR is your proposal**.
+
+### How to Make Revisions
+
+1. Go to your PR and navigate to the "Files changed" tab.
+2. Click the pencil icon (Edit) on your project page file.
+3. Make your changes and commit them directly to the PR branch.
+
+Every commit automatically updates the PR description to stay in sync with your project page. You can
+also clone the branch locally and push changes using git.
+
+### Review Process
+
+- Community members and reviewers (SCF Pilots) leave feedback directly on the PR using comments and
+  GitHub's **Suggest Changes** feature.
+- When you accept a suggested change, it counts as a commit, so the PR description updates
+  automatically.
+- All formal discussion and feedback happens on the PR. We encourage you to also post a thread in
+  **#projects** on the [Stellar Developers Discord](https://discord.gg/stellardev){:target="⚡"} for
+  broader informal discussion, which can continue outside of the Public Goods Award quarterly cycle.
+
+## Renewals
+
+Projects that received a previous Award **do not fill out the Proposal Form again**. Instead, you
+update your existing project page directly:
+
+1. Navigate to your project page in the
+   [`docs/projects/`](https://github.com/SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io/tree/main/docs/projects){:target="⚡"}
+   directory on the `main` branch.
+2. Click the **Edit** (pencil) icon on your project page.
+3. Update the relevant sections: new retroactive impact, deliverable evidence, next-quarter goals,
+   and updated budget.
+4. Choose **"Create a new branch for this commit and start a pull request."**
+5. Name your branch following the convention: `proposals/{slug}-{quarter}` (e.g.,
+   `proposals/stellar-sdk-2026q3`).
+
+Because the sync automation triggers on any PR that modifies files in `docs/projects/`, your PR
+description will automatically populate with the content of your updated project page. The renewal PR
+then goes through the same Discussion & Revisions → On-chain Vote → Payout cycle as new proposals.
+
+## Access & Permissions
+
+Proposers need to be added to the GitHub team corresponding to their SCF membership role. Those that
+are not SCF Pilots are added to the `pg-maintainer` team to get the write permission needed to create
+and edit PRs without forking.
+
+If you do not have write access to this repository, contact an active SCF Pilot or SDF representative
+to be added to the appropriate team before submitting your proposal.

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -1,0 +1,11 @@
+---
+title: Public Good Projects
+has_children: true
+nav_order: 5
+---
+
+# Public Good Projects
+
+Active and past project proposals for the SCF Public Goods Award. Each project page is a living
+document maintained via Pull Request. Accepted proposals are merged into this section, creating a
+persistent record of the project's evolution across Award rounds.


### PR DESCRIPTION
Merging is required to E2E test. Code and process review will proceed after testing.

- `docs/pg-award/proposer-instructions.md`: full proposer lifecycle guide (intake, proposal, D&R, renewals) with Mermaid flowcharts
- `docs/projects.md`: parent page for project proposals nav section
- `.github/scripts/render_proposal.py`: converts parsed issue form to Jekyll project page with front matter and structured sections
- `.github/workflows/pg-award-proposal-genesis.yml`: Issue -> PR pipeline (parse, validate, render, branch, PR, close issue, label)
- `.github/workflows/pg-award-proposal-sync.yml`: syncs project page edits back to PR body (strip front matter, truncate at 64k)
- `docs/_includes/footer_custom.html`: add Mermaid v11 CDN script for dynamic diagram rendering in Jekyll pages