### PR TITLE
Update flow with merged PRs on proposal

### DIFF
--- a/docs/pg-award/proposer-instructions.md
+++ b/docs/pg-award/proposer-instructions.md
@@ -119,13 +119,13 @@ flowchart TD
     %% VOTING PATH (Semantic: Follows D&R End)
     DiscRev --> |"D&R phase ends"| Finalized["Proposal finalized\n(D&R window closed)"]
 
-    Finalized --> TansuVote["Proposal submitted to\nTansu for on-chain vote"]
+    Finalized --> TansuVote["Proposal PR merged\nand automatically submitted to\nTansu for on-chain vote"]
     TansuVote --> PilotsVote["SCF Pilots vote\n(NQG-weighted, ~3 days)"]
     PilotsVote --> VoteOutcome{"Approved?"}
 
     %% FINAL OUTCOMES
     VoteOutcome --> |"Yes"| Compliance["Handoff to SDF for\ncompliance check"]
-    VoteOutcome --> |"No"| Rejected["Proposal not awarded\n(PR is not merged)"]
+    VoteOutcome --> |"No"| Rejected["Proposal not awarded"]
 
     Compliance --> ComplianceOutcome{"SDF compliance\npassed?"}
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -7,5 +7,5 @@ nav_order: 5
 # Public Good Projects
 
 Active and past project proposals for the SCF Public Goods Award. Each project page is a living
-document maintained via Pull Request. Accepted proposals are merged into this section, creating a
+document maintained via Pull Request. Both accepted and rejected proposals are merged into this section, creating a
 persistent record of the project's evolution across Award rounds.

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -7,5 +7,5 @@ nav_order: 5
 # Public Good Projects
 
 Active and past project proposals for the SCF Public Goods Award. Each project page is a living
-document maintained via Pull Request. Both accepted and rejected proposals are merged into this section, creating a
-persistent record of the project's evolution across Award rounds.
+document maintained via Pull Request. Both accepted and rejected proposals are merged into this
+section, creating a persistent record of the project's evolution across Award rounds.


### PR DESCRIPTION
We now want to have all proposals listed on the website regardless of the voting outcome. That will imply to show clearly proposal status on the website.

This follows the principles set on the community website where there is a record of all projects.