### PR TITLE
Add manually-triggered Format Docs workflow

### DIFF
--- a/.github/workflows/format-docs.yml
+++ b/.github/workflows/format-docs.yml
@@ -1,0 +1,47 @@
+name: Format Docs
+
+on:
+  workflow_dispatch: # Manually triggered from the Actions tab
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run formatters on all files
+        run: pre-commit run --all-files || true
+
+      - name: Open a PR with the formatting changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if git diff --quiet; then
+            echo "::notice::Everything already formatted — nothing to do."
+            exit 0
+          fi
+
+          BRANCH="chore/format-docs-${{ github.run_number }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$BRANCH"
+          git commit -am "Apply pre-commit formatting"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Apply pre-commit formatting" \
+            --body "Automated full-repo formatting (\`pre-commit run --all-files\`), triggered manually via workflow_dispatch."

--- a/docs/projects/opengrants.md
+++ b/docs/projects/opengrants.md
@@ -77,7 +77,8 @@ impact to the Stellar ecosystem:
   graph.
 - OpenGrants continued to ensure Stellar’s continued 100% DAOIP-5 compliance rate
 - OpenGrants expanded its ecosystem funding datasets, onboarding and integrating data from both ENS
-and Gitcoin, enabling greater comparative analytic capabilities
+  and Gitcoin, enabling greater comparative analytic capabilities
+
 <!-- markdownlint-enable MD034 -->
 
 ## Past Deliverables
@@ -115,7 +116,8 @@ Updated OpenGrants in accordance with ecosystem participant feedback
   integration
   ([Opengrants <> Stellar Community Fund Pipeline](https://hackmd.io/l9sHEdXZRDmkPFjwCSOO1g))
 - OpenGrants roadmap to prioritize fully automated data ingestion according to feedback received from
-PG Atlas team
+  PG Atlas team
+
 <!-- markdownlint-enable MD034 -->
 
 ## Proposed Impact

--- a/docs/projects/scout.md
+++ b/docs/projects/scout.md
@@ -141,6 +141,7 @@ As suggested in the SDF review:
 - During Month 1, we engaged with the SDF Security/Audit Bank, presenting detector proposals.
 - We delivered new POC metrics.
 - We ran the POC using an expanded set of contracts.
+
 <!-- markdownlint-enable MD034 -->
 
 ## Proposed Impact
@@ -193,6 +194,7 @@ Month 3 – AI Agent POC Iteration 2
 - Expanded set of contracts for testing.
 - Results and findings document.
 - Roadmap from AI POC to a beta-ready product.
+
 <!-- markdownlint-enable MD034 -->
 
 ## Legal Acknowledgements


### PR DESCRIPTION
## What

Add a manually-triggered `Format Docs` workflow that runs `pre-commit run
--all-files` and opens a PR with any formatting fixes.

## Why

pre-commit.ci always formats **all files** (it can't be scoped to a PR's changes). When `main` drifts out of compliance, it reformats unrelated pages into a contributor's PR, tripping the "one project page per PR" guard in `pg-award-proposal-sync.yml` and blocking the PR (e.g. #89).